### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,11 @@ setup(
 	author='Malcolm Diller',
 	author_email='malcolm@dillerm.io',
 	url='https://github.com/mdiller/dotabase',
-	license='MIT',
 	keywords='dota dota2 data sqlite',
 	include_package_data=True,
 	packages=['dotabase'],
 	install_requires=['sqlalchemy'],
+        classifiers=[
+            'License :: OSI Approved :: MIT License'
+        ],
 )


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.